### PR TITLE
feat: add CLI options and skip permissions to new session dialog

### DIFF
--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -137,6 +137,11 @@ export class SessionManager {
       command = getToolCommand(options.tool)
     }
 
+    // Append extra CLI flags if provided
+    if (options.cliOptions?.trim()) {
+      command = `${command} ${options.cliOptions.trim()}`
+    }
+
     log("Creating tmux session:", tmuxName, "command:", command)
 
     // Create tmux session
@@ -159,6 +164,9 @@ export class SessionManager {
     const toolData: Record<string, unknown> = {}
     if (options.tool === "claude" && options.claudeOptions) {
       toolData.claudeSessionMode = options.claudeOptions.sessionMode
+    }
+    if (options.cliOptions?.trim()) {
+      toolData.cliOptions = options.cliOptions.trim()
     }
 
     const session: Session = {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -86,6 +86,7 @@ export interface SessionCreateOptions {
   worktreeRepo?: string
   worktreeBranch?: string
   claudeOptions?: ClaudeOptions
+  cliOptions?: string          // extra CLI flags appended to the command
 }
 
 export interface SessionForkOptions {


### PR DESCRIPTION
Thank you for this tool, this is exactly what I needed 👍 I do run claude with `--dangerously-skip-permissions` so I added this in my fork, if you are interested.

## Summary

Adds two new features to the new session dialog:

- **CLI Options field** — A free-form input with autocomplete history that lets users pass extra CLI flags (e.g. `--model`, `--verbose`) to any agent tool command. The flags are appended to the tool command at session creation.
- **Dangerously skip permissions checkbox** — A Claude-specific toggle that adds `--dangerously-skip-permissions` to the session command. Appears alongside the existing "Resume previous session" checkbox when Claude is selected as the tool.

### Changes

- `src/core/types.ts` — Add `cliOptions` field to `SessionCreateOptions`
- `src/core/session.ts` — Append CLI options to the tool command and persist them in tool data
- `src/tui/component/dialog-new.tsx` — Add the CLI options input field with autocomplete, the skip permissions checkbox, arrow key navigation between Claude checkboxes, and history tracking

### Demo

When creating a new session:
1. Select any tool → the "CLI Options" field appears below the tool-specific options
2. Select Claude → a "Dangerously skip permissions" checkbox appears alongside "Resume previous session"
3. Both checkboxes support space to toggle and arrow keys to navigate between them
4. Previously used CLI options are suggested via autocomplete

## Test plan

- [ ] Create a Claude session with "Dangerously skip permissions" checked — verify `--dangerously-skip-permissions` flag is passed
- [ ] Create a session with custom CLI options — verify flags are appended to the command
- [ ] Verify CLI options autocomplete suggests previously used values
- [ ] Verify arrow key navigation works between Claude checkboxes
- [ ] Verify non-Claude tools don't show the skip permissions checkbox
- [ ] Verify `bun run typecheck` passes
- [ ] Verify `bun test` passes