### PR TITLE
Fix --version flag to read version from package.json

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@
  */
 
 import { tui } from "./tui/app"
+import pkg from "../package.json"
 
 async function main() {
   const args = process.argv.slice(2)
@@ -11,10 +12,10 @@ async function main() {
   // Simple CLI argument handling
   if (args.includes("--help") || args.includes("-h")) {
     console.log(`
-Agent Orchestrator - Terminal Agent Management
+Agent View - Terminal Agent Management
 
 Usage:
-  agent-orchestrator [options]
+  agent-view [options]
 
 Options:
   --help, -h     Show this help message
@@ -32,7 +33,7 @@ Keyboard Shortcuts (in TUI):
   }
 
   if (args.includes("--version") || args.includes("-v")) {
-    console.log("agent-orchestrator v1.0.0")
+    console.log(`agent-view v${pkg.version}`)
     process.exit(0)
   }
 


### PR DESCRIPTION
## Summary
- The `--version` flag was hardcoded to print `agent-orchestrator v1.0.0` instead of reading the actual version from `package.json` (currently `0.0.16`)
- Updated the version output to dynamically read from `package.json`, so it stays in sync automatically
- Updated help text to use the correct project name `agent-view` instead of `agent-orchestrator`

## Test plan
- Run `agent-view --version` and verify it prints `agent-view v0.0.16`
- Run `agent-view -v` and verify the same output
- Run `agent-view --help` and verify it shows "Agent View" and `agent-view` in usage