### PR TITLE
Prompt to delete worktree when deleting a session

### DIFF
--- a/src/tui/context/sync.tsx
+++ b/src/tui/context/sync.tsx
@@ -102,8 +102,8 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           refresh()
           return session
         },
-        async delete(id: string): Promise<void> {
-          await manager.delete(id)
+        async delete(id: string, options?: { deleteWorktree?: boolean }): Promise<void> {
+          await manager.delete(id, options)
           refresh()
         },
         async restart(id: string): Promise<Session> {

--- a/src/tui/routes/home.tsx
+++ b/src/tui/routes/home.tsx
@@ -9,6 +9,7 @@ import { useTerminalDimensions, useKeyboard, useRenderer } from "@opentui/solid"
 import { useTheme } from "@tui/context/theme"
 import { useSync } from "@tui/context/sync"
 import { useDialog } from "@tui/ui/dialog"
+import { DialogSelect } from "@tui/ui/dialog-select"
 import { useToast } from "@tui/ui/toast"
 import { DialogNew } from "@tui/component/dialog-new"
 import { DialogFork } from "@tui/component/dialog-fork"
@@ -254,6 +255,30 @@ export function Home() {
   }
 
   async function handleDelete(session: Session) {
+    if (session.worktreePath) {
+      dialog.replace(() => (
+        <DialogSelect
+          title={`Delete "${session.title}"?`}
+          options={[
+            { title: "Delete session and worktree", value: "delete-worktree" },
+            { title: "Delete session only", value: "delete-session" },
+          ]}
+          onSelect={async (opt) => {
+            dialog.clear()
+            try {
+              await sync.session.delete(session.id, { deleteWorktree: opt.value === "delete-worktree" })
+              const msg = opt.value === "delete-worktree"
+                ? `Deleted ${session.title} and worktree`
+                : `Deleted ${session.title}`
+              toast.show({ message: msg, variant: "info", duration: 2000 })
+            } catch (err) {
+              toast.error(err as Error)
+            }
+          }}
+        />
+      ))
+      return
+    }
     try {
       await sync.session.delete(session.id)
       toast.show({ message: `Deleted ${session.title}`, variant: "info", duration: 2000 })


### PR DESCRIPTION
## Summary
- When deleting a session that has a git worktree, a dialog now asks whether to also delete the worktree or just the session
- Previously, deleting a session with a worktree would orphan the worktree directory on disk
- Sessions without worktrees are deleted immediately as before (no dialog)

## Changes
- **`src/core/session.ts`**: Added optional `deleteWorktree` flag to `delete()`, calls `removeWorktree()` (which already existed in `git.ts` but was never used)
- **`src/tui/context/sync.tsx`**: Pass through `deleteWorktree` option
- **`src/tui/routes/home.tsx`**: Show `DialogSelect` prompt on delete when session has a worktree
- **`src/tui/component/dialog-sessions.tsx`**: Same prompt in the session list dialog

## Test plan
- Create a session with a git worktree
- Press `d` to delete it — verify a dialog appears with two options
- Select "Delete session and worktree" — verify both the session and worktree directory are removed
- Repeat and select "Delete session only" — verify the session is removed but the worktree directory remains
- Delete a session without a worktree — verify it deletes immediately with no dialog