### PR TITLE
Add auto-update checker

### DIFF
--- a/src/core/updater.ts
+++ b/src/core/updater.ts
@@ -1,0 +1,69 @@
+/**
+ * Auto-updater
+ * Checks GitHub for newer releases and runs install script to update
+ */
+
+import pkg from "../../package.json"
+
+interface GitHubRelease {
+  tag_name: string
+}
+
+function compareVersions(current: string, latest: string): boolean {
+  const currentParts = current.split(".").map(Number)
+  const latestParts = latest.split(".").map(Number)
+  const len = Math.max(currentParts.length, latestParts.length)
+
+  for (let i = 0; i < len; i++) {
+    const c = currentParts[i] ?? 0
+    const l = latestParts[i] ?? 0
+    if (l > c) return true
+    if (l < c) return false
+  }
+
+  return false
+}
+
+export async function checkForUpdate(): Promise<{ current: string; latest: string } | null> {
+  try {
+    const response = await fetch("https://api.github.com/repos/frayo44/agent-view/releases/latest", {
+      headers: { "Accept": "application/vnd.github.v3+json" },
+      signal: AbortSignal.timeout(5000)
+    })
+
+    if (!response.ok) return null
+
+    const data = (await response.json()) as GitHubRelease
+    const latest = data.tag_name.replace(/^v/, "")
+    const current = pkg.version
+
+    if (compareVersions(current, latest)) {
+      return { current, latest }
+    }
+
+    return null
+  } catch {
+    return null
+  }
+}
+
+export function performUpdateSync(): void {
+  const { spawnSync } = require("child_process")
+
+  // Exit alternate screen buffer
+  process.stdout.write("\x1b[?1049l")
+  process.stdout.write("\x1b[2J\x1b[H")
+  process.stdout.write("\x1b[?25h")
+
+  spawnSync("bash", ["-c", "curl -fsSL https://raw.githubusercontent.com/frayo44/agent-view/main/install.sh | bash"], {
+    stdio: "inherit",
+    env: process.env
+  })
+
+  // Clear screen and re-enter alternate buffer for TUI
+  process.stdout.write("\x1b[2J\x1b[H")
+  process.stdout.write("\x1b[?1049h")
+
+  // Restore terminal title
+  process.stdout.write("\x1b]0;Agent View\x07")
+}

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -17,7 +17,7 @@ function log(...args: unknown[]) {
   const msg = `[${new Date().toISOString()}] ${args.map(a => typeof a === "object" ? JSON.stringify(a) : String(a)).join(" ")}\n`
   fs.appendFileSync(logFile, msg)
 }
-import { Switch, Match, createEffect, ErrorBoundary, Show, onMount } from "solid-js"
+import { Switch, Match, createEffect, ErrorBoundary, Show, onMount, createSignal } from "solid-js"
 import { RouteProvider, useRoute } from "@tui/context/route"
 import { SyncProvider, useSync } from "@tui/context/sync"
 import { ThemeProvider, useTheme } from "@tui/context/theme"
@@ -30,6 +30,8 @@ import { ToastProvider, useToast } from "@tui/ui/toast"
 import { CommandProvider, useCommandDialog } from "@tui/component/dialog-command"
 import { DialogSessions } from "@tui/component/dialog-sessions"
 import { DialogNew } from "@tui/component/dialog-new"
+import { DialogUpdate } from "@tui/component/dialog-update"
+import { checkForUpdate } from "@/core/updater"
 import { Home } from "@tui/routes/home"
 import { Session } from "@tui/routes/session"
 import { getStorage, setStorage, Storage } from "@/core/storage"
@@ -136,10 +138,41 @@ function App(props: { onExit: () => Promise<void>; onRendererReady: (r: CliRende
 
   log("App initialized, route:", route.data.type, "dimensions:", dimensions().width, "x", dimensions().height)
 
+  const [updateInfo, setUpdateInfo] = createSignal<{ current: string; latest: string } | null>(null)
+  const kv = useKV()
+
   // Disable stdout interception to allow keyboard input
   onMount(() => {
     renderer.disableStdoutInterception()
     props.onRendererReady(renderer)
+  })
+
+  // Check for updates in background
+  onMount(() => {
+    checkForUpdate().then((info) => {
+      if (!info) return
+      setUpdateInfo(info)
+      kv.set("updateInfo", info)
+
+      toast.show({
+        title: "🎉 Update available",
+        message: `v${info.latest} (current: v${info.current}) — press U to update`,
+        variant: "info",
+        duration: 10000
+      })
+
+      command.register(() => [
+        {
+          title: "Update agent-view",
+          value: "app.update",
+          category: "System",
+          suggested: true,
+          onSelect: () => {
+            dialog.replace(() => <DialogUpdate current={info.current} latest={info.latest} />)
+          }
+        }
+      ])
+    })
   })
 
   // Register global commands
@@ -208,6 +241,13 @@ function App(props: { onExit: () => Promise<void>; onRendererReady: (r: CliRende
     if (evt.name === "l") {
       log("Opening sessions dialog from App")
       dialog.replace(() => <DialogSessions />)
+    }
+
+    if (evt.name === "u") {
+      const info = updateInfo()
+      if (info) {
+        dialog.replace(() => <DialogUpdate current={info.current} latest={info.latest} />)
+      }
     }
 
     if (evt.name === "q") {

--- a/src/tui/component/dialog-update.tsx
+++ b/src/tui/component/dialog-update.tsx
@@ -1,0 +1,81 @@
+/**
+ * Update dialog
+ * Shows current/latest version and allows updating
+ */
+
+import { createSignal } from "solid-js"
+import { useKeyboard, useRenderer } from "@opentui/solid"
+import { useTheme } from "@tui/context/theme"
+import { useDialog } from "@tui/ui/dialog"
+import { useToast } from "@tui/ui/toast"
+import { DialogHeader } from "@tui/ui/dialog-header"
+import { DialogFooter } from "@tui/ui/dialog-footer"
+import { ActionButton } from "@tui/ui/action-button"
+import { performUpdateSync } from "@/core/updater"
+
+interface DialogUpdateProps {
+  current: string
+  latest: string
+}
+
+export function DialogUpdate(props: DialogUpdateProps) {
+  const dialog = useDialog()
+  const toast = useToast()
+  const { theme } = useTheme()
+  const renderer = useRenderer()
+
+  const [updating, setUpdating] = createSignal(false)
+
+  function handleUpdate() {
+    if (updating()) return
+    setUpdating(true)
+
+    dialog.clear()
+    renderer.suspend()
+
+    try {
+      performUpdateSync()
+    } catch (err) {
+      console.error("Update error:", err)
+    }
+
+    renderer.resume()
+    toast.show({
+      title: "Update complete",
+      message: "Restart agent-view to use the new version",
+      variant: "success",
+      duration: 8000
+    })
+  }
+
+  useKeyboard((evt) => {
+    if (evt.name === "return" && !evt.shift) {
+      evt.preventDefault()
+      handleUpdate()
+    }
+  })
+
+  return (
+    <box gap={1} paddingBottom={1}>
+      <DialogHeader title="Update Agent View" />
+
+      <box paddingLeft={4} paddingRight={4} paddingTop={1} gap={1} flexDirection="column">
+        <text fg={theme.text}>
+          Current version: <span style={{ fg: theme.textMuted }}>v{props.current}</span>
+        </text>
+        <text fg={theme.text}>
+          Latest version:  <span style={{ fg: theme.success }}>v{props.latest}</span>
+        </text>
+      </box>
+
+      <ActionButton
+        label="Update now"
+        loadingLabel="Updating..."
+        loading={updating()}
+        onAction={handleUpdate}
+      />
+
+      <DialogFooter hint="Enter: update | Esc: cancel" />
+    </box>
+  )
+}

--- a/src/tui/routes/home.tsx
+++ b/src/tui/routes/home.tsx
@@ -20,6 +20,8 @@ import { DialogShortcuts } from "@tui/component/dialog-shortcuts"
 import { getShortcuts } from "@/core/config"
 import { executeShortcut, getShortcutGroupPath } from "@/core/shortcut"
 import { useKeybind } from "@tui/context/keybind"
+import { useKV } from "@tui/context/kv"
+import { DialogUpdate } from "@tui/component/dialog-update"
 import { attachSessionSync, capturePane, wasCommandPaletteRequested } from "@/core/tmux"
 import { canFork } from "@/core/claude"
 import { useCommandDialog } from "@tui/component/dialog-command"
@@ -80,8 +82,10 @@ export function Home() {
   const renderer = useRenderer()
   const command = useCommandDialog()
   const keybind = useKeybind()
+  const kv = useKV()
 
   const shortcuts = createMemo(() => getShortcuts())
+  const updateInfo = () => kv.get<{ current: string; latest: string } | null>("updateInfo", null)
 
   const [selectedIndex, setSelectedIndex] = createSignal(0)
   const [previewContent, setPreviewContent] = createSignal<string>("")
@@ -474,6 +478,15 @@ export function Home() {
           return
         }
         dialog.push(() => <DialogFork session={session} />)
+      }
+      return
+    }
+
+    // u to open update dialog
+    if (evt.name === "u" && !evt.shift && !evt.ctrl) {
+      const info = updateInfo()
+      if (info) {
+        dialog.push(() => <DialogUpdate current={info.current} latest={info.latest} />)
       }
       return
     }
@@ -897,6 +910,12 @@ export function Home() {
           <text fg={theme.text}>q</text>
           <text fg={theme.textMuted}>quit</text>
         </box>
+        <Show when={updateInfo()}>
+          <box flexDirection="column" alignItems="center">
+            <text fg={theme.success}>u</text>
+            <text fg={theme.success}>update</text>
+          </box>
+        </Show>
       </box>
     </box>
   )


### PR DESCRIPTION
<img width="956" height="482" alt="image" src="https://github.com/user-attachments/assets/a6412af9-efd2-4215-8300-2f1f91c95a22" />

## Summary
- Check GitHub releases on TUI startup (background, non-blocking) and show a toast if a newer version exists
- Press **U** to open an update dialog that runs the install script
- Green **u / update** keybind appears in the home footer when an update is available
- "Update agent-view" command also registered in the command palette

## New files
- `src/core/updater.ts` — `checkForUpdate()` fetches latest GitHub release, `performUpdateSync()` runs install script
- `src/tui/component/dialog-update.tsx` — Update dialog with version info and "Update now" button

## Modified files
- `src/tui/app.tsx` — fires update check on mount, shows toast, registers command + U keybind
- `src/tui/routes/home.tsx` — adds U keybind handler and footer hint

## Test plan
- [x] `bun run build` succeeds
- [x] `bun test` passes
- [ ] Launch TUI — if behind latest GitHub release, toast appears with 🎉
- [ ] Press U — update dialog opens with version info
- [ ] "Update now" runs install script in terminal, then shows success toast