### PR TITLE
fix: abbreviate home directory in project path to prevent truncation

### DIFF
--- a/src/tui/component/dialog-new.tsx
+++ b/src/tui/component/dialog-new.tsx
@@ -78,7 +78,15 @@ export function DialogNew() {
   const [title, setTitle] = createSignal("")
   const [selectedTool, setSelectedTool] = createSignal<Tool>(defaultTool)
   const [customCommand, setCustomCommand] = createSignal("")
-  const [projectPath, setProjectPath] = createSignal(process.cwd())
+  // Abbreviate home directory as ~ to prevent long paths from being clipped
+  const home = process.env.HOME || ""
+  const cwd = home && process.cwd().startsWith(home)
+    ? process.cwd().replace(home, "~")
+    : process.cwd()
+  const [projectPath, setProjectPath] = createSignal(cwd)
+  // Expand ~ back to full path for filesystem operations
+  const expandPath = (p: string) =>
+    home && p.startsWith("~") ? p.replace("~", home) : p
   const [creating, setCreating] = createSignal(false)
   const [statusMessage, setStatusMessage] = createSignal("")
   const [spinnerFrame, setSpinnerFrame] = createSignal(0)
@@ -121,7 +129,7 @@ export function DialogNew() {
   })
 
   createEffect(async () => {
-    const path = projectPath()
+    const path = expandPath(projectPath())
     try {
       const result = await isGitRepo(path)
       setIsInGitRepo(result)
@@ -203,11 +211,7 @@ export function DialogNew() {
         throw new Error("Please enter a custom command")
       }
 
-      let sessionProjectPath = projectPath().trim() || process.cwd()
-      // Expand ~ to home directory (shell doesn't do this for us)
-      if (sessionProjectPath.startsWith("~")) {
-        sessionProjectPath = sessionProjectPath.replace("~", process.env.HOME || "")
-      }
+      let sessionProjectPath = expandPath(projectPath().trim()) || process.cwd()
       if (!existsSync(sessionProjectPath)) {
         throw new Error(`Directory '${sessionProjectPath}' does not exist`)
       }
@@ -226,7 +230,7 @@ export function DialogNew() {
 
       if (useWorktree() && isInGitRepo()) {
         setStatusMessage("Creating worktree...")
-        const repoRoot = await getRepoRoot(projectPath())
+        const repoRoot = await getRepoRoot(expandPath(projectPath()))
         const branchName = worktreeBranch()
           ? sanitizeBranchName(worktreeBranch())
           : generateBranchName(title() || undefined)


### PR DESCRIPTION
## Summary

Long absolute paths get clipped in the New Session dialog's Project Path field. For example, `/Users/bobjohnson/Projects/02-Personal/agent-view` displays as `objohnson/Projects/02-Personal/agent-view` with the leading characters cut off.

This replaces the full home directory prefix with `~` in the default path value, matching standard terminal conventions. `~/Projects/02-Personal/agent-view` fits comfortably in the input field.

## Changes

- Default project path now uses `~` instead of the full home directory path
- Added `expandPath()` helper that converts `~` back to the full path for all filesystem operations (git repo detection, session creation, worktree setup)
- Consolidated the existing inline `~` expansion into the shared helper
- History entries store the abbreviated form for consistent display

## Test plan

- [x] All 140 tests pass
- [x] TypeScript typecheck clean
- [x] Build succeeds
- [x] Verified path displays as `~/Projects/...` instead of `/Users/username/Projects/...`
- [x] Verified session creation works correctly with `~`-prefixed paths
- [x] Verified git repo detection works with abbreviated paths