### PR TITLE
Offer to resume stopped sessions on Enter

### DIFF
--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -396,6 +396,51 @@ export class SessionManager {
     storage.touch()
   }
 
+  async resume(sessionId: string): Promise<Session> {
+    const storage = getStorage()
+    const session = storage.getSession(sessionId)
+
+    if (!session) {
+      throw new Error(`Session not found: ${sessionId}`)
+    }
+
+    if (session.tmuxSession) {
+      await tmux.killSession(session.tmuxSession)
+    }
+
+    // For Claude sessions with a claudeSessionId, resume the existing conversation
+    const claudeSessionId = session.tool === "claude" && session.toolData?.claudeSessionId
+      ? (session.toolData.claudeSessionId as string)
+      : undefined
+
+    const command = claudeSessionId
+      ? `claude --resume ${claudeSessionId}`
+      : session.command
+
+    const env: Record<string, string> = { AGENT_ORCHESTRATOR_SESSION: session.id }
+    if (claudeSessionId) {
+      env.CLAUDE_SESSION_ID = claudeSessionId
+    }
+
+    const newTmuxName = tmux.generateSessionName(session.title)
+    await tmux.createSession({
+      name: newTmuxName,
+      command,
+      cwd: session.projectPath,
+      env
+    })
+
+    session.tmuxSession = newTmuxName
+    session.command = command
+    session.status = "running"
+    session.lastAccessed = new Date()
+
+    storage.saveSession(session)
+    storage.touch()
+
+    return session
+  }
+
   async restart(sessionId: string): Promise<Session> {
     const storage = getStorage()
     const session = storage.getSession(sessionId)

--- a/src/tui/context/sync.tsx
+++ b/src/tui/context/sync.tsx
@@ -106,6 +106,11 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           await manager.delete(id, options)
           refresh()
         },
+        async resume(id: string): Promise<Session> {
+          const session = await manager.resume(id)
+          refresh()
+          return session
+        },
         async restart(id: string): Promise<Session> {
           const session = await manager.restart(id)
           refresh()

--- a/src/tui/routes/home.tsx
+++ b/src/tui/routes/home.tsx
@@ -235,12 +235,7 @@ export function Home() {
     sync.refresh()
   }
 
-  function handleAttach(session: Session) {
-    if (!session.tmuxSession) {
-      toast.show({ message: "Session has no tmux session", variant: "error", duration: 2000 })
-      return
-    }
-
+  function doAttach(session: Session) {
     previewFetchAbort = true
     renderer.suspend()
     try {
@@ -255,6 +250,50 @@ export function Home() {
     if (wasCommandPaletteRequested()) {
       command.open()
     }
+  }
+
+  function handleAttach(session: Session) {
+    if (!session.tmuxSession) {
+      toast.show({ message: "Session has no tmux session", variant: "error", duration: 2000 })
+      return
+    }
+
+    // If session is stopped, offer to resume or restart
+    if (session.status === "stopped") {
+      const isClaudeWithSession = session.tool === "claude" && session.toolData?.claudeSessionId
+      const options = [
+        ...(isClaudeWithSession
+          ? [{ title: "Resume session", value: "resume" }]
+          : []),
+        { title: "Restart session", value: "restart" },
+      ]
+
+      dialog.replace(() => (
+        <DialogSelect
+          title={`"${session.title}" is stopped`}
+          options={options}
+          onSelect={async (opt) => {
+            dialog.clear()
+            try {
+              let updated: Session
+              if (opt.value === "resume") {
+                updated = await sync.session.resume(session.id)
+              } else {
+                updated = await sync.session.restart(session.id)
+              }
+              toast.show({ message: `Session ${opt.value === "resume" ? "resumed" : "restarted"}`, variant: "success", duration: 2000 })
+              sync.refresh()
+              doAttach(updated)
+            } catch (err) {
+              toast.error(err as Error)
+            }
+          }}
+        />
+      ))
+      return
+    }
+
+    doAttach(session)
   }
 
   async function handleDelete(session: Session) {


### PR DESCRIPTION
## Summary

- When pressing Enter on a stopped session, shows a dialog offering to **resume** (Claude sessions with a stored session ID) or **restart** (all sessions), instead of silently failing
- Adds `resume()` method to `SessionManager` that reuses the existing Claude session ID with `claude --resume <id>`
- Non-Claude sessions fall back to restarting with the original command

## Multi-tool support

Resume is currently Claude-specific (`claude --resume <id>`). For non-Claude tools (OpenCode, Gemini, Codex, custom commands), the dialog only shows "Restart session" which re-runs the original command. If other tools add resume support in the future, this can be extended per-tool.

## Test plan

- [ ] Kill AV while sessions are running, restart AV
- [ ] Press Enter on a stopped Claude session → dialog appears with "Resume session" and "Restart session"
- [ ] Select "Resume session" → session resumes with conversation history
- [ ] Press Enter on a stopped non-Claude session → dialog appears with "Restart session" only
- [ ] Select "Restart session" → session restarts fresh
- [ ] `bun run build` compiles cleanly
- [ ] `bun test` passes (140 tests)