### PR TITLE
Fix Claude Code sessions failing to launch from tmux

### DIFF
--- a/src/core/tmux.ts
+++ b/src/core/tmux.ts
@@ -204,6 +204,11 @@ export async function createSession(options: {
     await execAsync(tmuxCmd(`set-environment -t "${options.name}" ${key} "${value}"`))
   }
 
+  // Unset Claude Code env vars inherited by the shell from the tmux server
+  // process (which may have been started from a Claude Code context).
+  // Must be sent to the shell directly since set-environment -r is too late.
+  await execAsync(tmuxCmd(`send-keys -t "${options.name}" "unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" Enter`))
+
   if (options.command) {
     let cmdToSend = options.command
 


### PR DESCRIPTION
## Problem

When `av` (or the tmux server it uses) is first started from within a Claude Code session, the tmux server inherits Claude Code's environment variables (`CLAUDECODE`, `CLAUDE_CODE_ENTRYPOINT`, `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`) into its global environment. Since the tmux server is long-lived and persists across `av` invocations, these env vars leak into **every** new tmux session — even ones started from a plain terminal. This causes all new Claude Code sessions to fail with:

```
Claude Code cannot be launched inside another Claude Code session.
```

### Why `set-environment -r` doesn't work

The tmux `set-environment -r` command removes a variable from the tmux session's environment, but the shell process inside the pane has **already inherited** the variable at spawn time. By the time we can call `set-environment`, it's too late — the shell already has `CLAUDECODE=1` in its process environment.

## Fix

Send `unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` directly to the shell via `send-keys` before sending the actual command. This clears the vars from the running shell's environment before Claude Code is launched.

## Test plan

- [x] Start `av` from within a Claude Code session (so the tmux server inherits the env vars)
- [x] Create a new Claude Code session — should launch successfully instead of erroring
- [x] `bun test` passes (140/140)