### PR TITLE
feat(tui): add folder browser to session creation dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ curl -fsSL https://raw.githubusercontent.com/frayo44/agent-view/main/install.sh 
 git clone git@github.com:frayo44/agent-view.git
 cd agent-view
 bun install
-bun run build
+bun run install-local
 ```
 
 ### Compile Standalone Binary

--- a/src/core/fs-dialog.ts
+++ b/src/core/fs-dialog.ts
@@ -1,0 +1,36 @@
+import { exec } from "child_process"
+import { promisify } from "util"
+
+const execAsync = promisify(exec)
+
+/**
+ * Opens a native OS folder selection dialog and returns the selected path.
+ * Supports macOS, Linux (via zenity), and Windows (via PowerShell).
+ * @param defaultPath Optional initial path for the dialog
+ * @returns The selected folder path or null if cancelled
+ */
+export async function openFolderDialog(defaultPath?: string): Promise<string | null> {
+  const platform = process.platform
+
+  try {
+    if (platform === "darwin") {
+      let script = `choose folder with prompt "Select Project Path:"`
+      if (defaultPath) {
+        script += ` default location POSIX file "${defaultPath}"`
+      }
+      const { stdout } = await execAsync(`osascript -e 'POSIX path of (${script})'`)
+      return stdout.trim() || null
+    } else if (platform === "linux") {
+      const { stdout } = await execAsync(`zenity --file-selection --directory --title="Select Project Path"`)
+      return stdout.trim() || null
+    } else if (platform === "win32") {
+      const psCommand = `(New-Object -ComObject Shell.Application).BrowseForFolder(0, 'Select Project Path', 0, 0).self.path`
+      const { stdout } = await execAsync(`powershell -NoProfile -Command "${psCommand}"`)
+      return stdout.trim() || null
+    }
+  } catch (err) {
+    // Usually means the user cancelled the dialog
+    return null
+  }
+  return null
+}

--- a/src/tui/component/dialog-new.tsx
+++ b/src/tui/component/dialog-new.tsx
@@ -23,6 +23,7 @@ import type { Tool, ClaudeSessionMode } from "@/core/types"
 import { getToolCommand } from "@/core/types"
 import { exec } from "child_process"
 import { promisify } from "util"
+import { openFolderDialog } from "@/core/fs-dialog"
 import { existsSync } from "fs"
 import path from "path"
 
@@ -61,7 +62,7 @@ const TOOLS: { value: Tool; label: string; description: string }[] = [
   { value: "shell", label: "Shell", description: "Plain terminal session" }
 ]
 
-type FocusField = "title" | "tool" | "resumeSession" | "skipPermissions" | "customCommand" | "path" | "worktree" | "branch"
+type FocusField = "title" | "tool" | "resumeSession" | "skipPermissions" | "customCommand" | "path" | "browsePath" | "worktree" | "branch"
 
 export function DialogNew() {
   const dialog = useDialog()
@@ -183,6 +184,7 @@ export function DialogNew() {
       fields.push("customCommand")
     }
     fields.push("path")
+    fields.push("browsePath")
     if (isInGitRepo()) {
       fields.push("worktree")
       if (useWorktree()) {
@@ -299,6 +301,19 @@ export function DialogNew() {
     if (evt.name === "escape") {
       evt.preventDefault()
       dialog.clear()
+      return
+    }
+
+    if (focusedField() === "browsePath" && (evt.name === "return" || evt.name === "space")) {
+      evt.preventDefault()
+      ;(async () => {
+        const selectedStr = await openFolderDialog(projectPath())
+        if (selectedStr) {
+          setProjectPath(selectedStr)
+          setFocusedField("path")
+          pathInputRef?.focus()
+        }
+      })()
       return
     }
 
@@ -508,9 +523,28 @@ export function DialogNew() {
 
       {/* Path field with autocomplete */}
       <box paddingLeft={4} paddingRight={4} paddingTop={1} gap={1}>
-        <text fg={focusedField() === "path" ? theme.primary : theme.textMuted}>
-          Project Path
-        </text>
+        <box flexDirection="row" justifyContent="space-between">
+          <text fg={focusedField() === "path" ? theme.primary : theme.textMuted}>
+            Project Path
+          </text>
+          <box
+            backgroundColor={focusedField() === "browsePath" ? theme.primary : undefined}
+            onMouseUp={async () => {
+              setFocusedField("browsePath")
+              const selectedStr = await openFolderDialog(projectPath())
+              if (selectedStr) {
+                setProjectPath(selectedStr)
+                // Refocus input
+                setFocusedField("path")
+                pathInputRef?.focus()
+              }
+            }}
+          >
+            <text fg={focusedField() === "browsePath" ? theme.background : theme.primary}>
+              [ Browse ]
+            </text>
+          </box>
+        </box>
         <InputAutocomplete
           value={projectPath()}
           onInput={setProjectPath}


### PR DESCRIPTION
<img width="478" height="600" alt="Screenshot 2026-03-08 at 7 52 57 AM" src="https://github.com/user-attachments/assets/1a6102dd-f2f1-48f4-9930-642a66bf948c" />

## Description
This PR improves the user experience for selecting a project path during new session creation by introducing an interactive folder browser. Instead of manually typing or pasting the path, users can now activate a `[ Browse ]` button to open their operating system's native file explorer and select a project directory directly.

## Key Changes
- **Cross-Platform Native Dialog**: Implemented a new `openFolderDialog` utility (`src/core/fs-dialog.ts`) that leverages system-native dialogs:
  - **macOS**: Prompts via `osascript`
  - **Linux**: Prompts via `zenity`
  - **Windows**: Prompts via `PowerShell`
- **UI Integration**: 
  - Added a `[ Browse ]` button alongside the "Project Path" input field in the new session dialog (`src/tui/component/dialog-new.tsx`).
  - Integrated proper keyboard navigation (focusing `browsePath` field) and activation (listening for `return` or `space`).
  - Added mouse support for clicking the `[ Browse ]` button.
- **Documentation Update**: Updated the manual install command in `README.md` to correctly use `bun run install-local` instead of `bun run build` for better consistency.

## Motivation and Context
Typing absolute or relative project paths manually is error-prone and degrades the user experience. This update streamlines session creation by offering an intuitive, MVP-focused way to locate and select the target workspace.

## GIF
![untitled](https://github.com/user-attachments/assets/b1e1a627-e716-4b8a-bd7f-5bcf665528bd)
