### PR TITLE
feat: delete session from within attached tmux session (Ctrl+D)

### DIFF
--- a/src/core/ssh.ts
+++ b/src/core/ssh.ts
@@ -139,7 +139,7 @@ export class SSHRunner {
 
     // Exit alternate screen buffer before attaching
     process.stdout.write("\x1b[?1049l")
-    process.stdout.write("\x1b[2J\x1b[H")
+    process.stdout.write("\x1b[2J\x1b[3J\x1b[H")
     process.stdout.write("\x1b[?25h")
 
     const sshArgs = [
@@ -159,7 +159,7 @@ export class SSHRunner {
 
     child.on("exit", () => {
       // Clear screen and re-enter alternate buffer for TUI
-      process.stdout.write("\x1b[2J\x1b[H")
+      process.stdout.write("\x1b[2J\x1b[3J\x1b[H")
       process.stdout.write("\x1b[?1049h")
       process.stdout.write("\x1b]0;Agent View\x07")
     })
@@ -175,7 +175,7 @@ export class SSHRunner {
 
     // Exit alternate screen buffer
     process.stdout.write("\x1b[?1049l")
-    process.stdout.write("\x1b[2J\x1b[H")
+    process.stdout.write("\x1b[2J\x1b[3J\x1b[H")
     process.stdout.write("\x1b[?25h")
 
     const sshArgs = [
@@ -207,7 +207,7 @@ export class SSHRunner {
     }
 
     // Clear screen and re-enter alternate buffer for TUI
-    process.stdout.write("\x1b[2J\x1b[H")
+    process.stdout.write("\x1b[2J\x1b[3J\x1b[H")
     process.stdout.write("\x1b[?1049h")
     process.stdout.write("\x1b]0;Agent View\x07")
 

--- a/src/core/tmux.conf
+++ b/src/core/tmux.conf
@@ -4,6 +4,7 @@
 #
 # Reserved keybinds (avoid overriding in tmux-user.conf):
 #   Ctrl+Q  - detach
+#   Ctrl+D  - delete session
 #   Ctrl+K  - command palette
 #   Ctrl+L  - session list
 #   Ctrl+T  - toggle terminal pane
@@ -13,6 +14,7 @@
 
 # --- Keybindings ---
 bind-key -n C-q detach-client
+bind-key -n C-d run-shell "touch /tmp/agent-view-delete-session" \; detach-client
 bind-key -n C-k run-shell "touch /tmp/agent-view-cmd-palette" \; detach-client
 bind-key -n C-t if-shell "[ $(tmux display -p '#{window_panes}') -eq 1 ]" "split-window -v" "kill-pane -t :.1"
 bind-key -n C-o select-pane -t :.+
@@ -31,7 +33,7 @@ set-option -g status-style "bg=#1e1e2e,fg=#cdd6f4"
 set-option -g status-left "#[fg=#a6e3a1,bold] #{window_name} #[fg=#6c7086]| "
 set-option -g status-left-length 30
 set-option -g status-right-length 120
-set-option -g status-right "#[fg=#89b4fa]Ctrl+]/\\#[fg=#6c7086] switch  #[fg=#89b4fa]Ctrl+L#[fg=#6c7086] list  #[fg=#89b4fa]Ctrl+T#[fg=#6c7086] term  #[fg=#89b4fa]Ctrl+K#[fg=#6c7086] cmd  #[fg=#89b4fa]Ctrl+Q#[fg=#6c7086] detach"
+set-option -g status-right "#[fg=#89b4fa]Ctrl+]/\\#[fg=#6c7086] switch  #[fg=#89b4fa]Ctrl+L#[fg=#6c7086] list  #[fg=#89b4fa]Ctrl+T#[fg=#6c7086] term  #[fg=#89b4fa]Ctrl+K#[fg=#6c7086] cmd  #[fg=#89b4fa]Ctrl+D#[fg=#6c7086] delete  #[fg=#89b4fa]Ctrl+Q#[fg=#6c7086] detach"
 
 # --- Terminal titles ---
 set-option -g set-titles on

--- a/src/core/tmux.conf
+++ b/src/core/tmux.conf
@@ -18,8 +18,10 @@ bind-key -n C-t if-shell "[ $(tmux display -p '#{window_panes}') -eq 1 ]" "split
 bind-key -n C-o select-pane -t :.+
 
 # Session switching (no prefix needed)
-bind-key -n C-] switch-client -n
-bind-key -n 'C-\' switch-client -p
+# refresh-client after switch forces a full terminal redraw to prevent
+# screen artifacts from the previous session.
+bind-key -n C-] switch-client -n \; refresh-client
+bind-key -n 'C-\' switch-client -p \; refresh-client
 bind-key -n C-l run-shell "touch /tmp/agent-view-session-list" \; detach-client
 
 # --- Status bar ---

--- a/src/core/tmux.ts
+++ b/src/core/tmux.ts
@@ -29,6 +29,7 @@ export const SESSION_PREFIX = "agentorch_"
 // Signal files for UI requests from tmux keybinds
 const COMMAND_PALETTE_SIGNAL = "/tmp/agent-view-cmd-palette"
 const SESSION_LIST_SIGNAL = "/tmp/agent-view-session-list"
+const DELETE_SESSION_SIGNAL = "/tmp/agent-view-delete-session"
 
 // --- Isolated tmux server configuration ---
 // All agent-view sessions run on a dedicated tmux socket with a custom config,
@@ -610,6 +611,18 @@ export function wasSessionListRequested(): boolean {
   return false
 }
 
+export function wasDeleteSessionRequested(): boolean {
+  try {
+    if (fs.existsSync(DELETE_SESSION_SIGNAL)) {
+      fs.unlinkSync(DELETE_SESSION_SIGNAL)
+      return true
+    }
+  } catch {
+    // Ignore errors
+  }
+  return false
+}
+
 /**
  * Attach to a tmux session with Ctrl+Q to detach
  * Keybindings and status bar are configured via the custom tmux.conf,
@@ -692,6 +705,11 @@ export function attachSessionSync(sessionName: string): void {
   }
   try {
     fs.unlinkSync(SESSION_LIST_SIGNAL)
+  } catch {
+    // Ignore if doesn't exist
+  }
+  try {
+    fs.unlinkSync(DELETE_SESSION_SIGNAL)
   } catch {
     // Ignore if doesn't exist
   }

--- a/src/core/tmux.ts
+++ b/src/core/tmux.ts
@@ -577,8 +577,8 @@ export async function attachWithPty(sessionName: string): Promise<void> {
         // PTY may already be closed
       }
 
-      // Clear screen before returning to TUI
-      process.stdout.write("\x1b[2J\x1b[H")
+      // Clear screen + scrollback before returning to TUI
+      process.stdout.write("\x1b[2J\x1b[3J\x1b[H")
     }
   })
 }
@@ -698,7 +698,7 @@ export function attachSessionSync(sessionName: string): void {
 
   // Exit alternate screen buffer (TUI uses this)
   process.stdout.write("\x1b[?1049l")
-  process.stdout.write("\x1b[2J\x1b[H")
+  process.stdout.write("\x1b[2J\x1b[3J\x1b[H") // Clear screen + scrollback
   process.stdout.write("\x1b[?25h")
 
   // Attach to tmux - this blocks until user detaches (Ctrl+Q or Ctrl+B d)
@@ -707,8 +707,8 @@ export function attachSessionSync(sessionName: string): void {
     env: process.env
   })
 
-  // Clear screen and re-enter alternate buffer for TUI
-  process.stdout.write("\x1b[2J\x1b[H")
+  // Clear screen + scrollback and re-enter alternate buffer for TUI
+  process.stdout.write("\x1b[2J\x1b[3J\x1b[H")
   process.stdout.write("\x1b[?1049h")
 
   // Restore terminal title to "Agent View"

--- a/src/core/updater.ts
+++ b/src/core/updater.ts
@@ -52,7 +52,7 @@ export function performUpdateSync(): void {
 
   // Exit alternate screen buffer
   process.stdout.write("\x1b[?1049l")
-  process.stdout.write("\x1b[2J\x1b[H")
+  process.stdout.write("\x1b[2J\x1b[3J\x1b[H")
   process.stdout.write("\x1b[?25h")
 
   spawnSync("bash", ["-c", "curl -fsSL https://raw.githubusercontent.com/frayo44/agent-view/main/install.sh | bash"], {
@@ -61,7 +61,7 @@ export function performUpdateSync(): void {
   })
 
   // Clear screen and re-enter alternate buffer for TUI
-  process.stdout.write("\x1b[2J\x1b[H")
+  process.stdout.write("\x1b[2J\x1b[3J\x1b[H")
   process.stdout.write("\x1b[?1049h")
 
   // Restore terminal title

--- a/src/tui/routes/home.tsx
+++ b/src/tui/routes/home.tsx
@@ -27,7 +27,7 @@ import { executeShortcut, getShortcutGroupPath } from "@/core/shortcut"
 import { useKeybind } from "@tui/context/keybind"
 import { useKV } from "@tui/context/kv"
 import { DialogUpdate } from "@tui/component/dialog-update"
-import { attachSessionSync, capturePane, wasCommandPaletteRequested, wasSessionListRequested, sendKeys } from "@/core/tmux"
+import { attachSessionSync, capturePane, wasCommandPaletteRequested, wasSessionListRequested, wasDeleteSessionRequested, sendKeys } from "@/core/tmux"
 import { useCommandDialog } from "@tui/component/dialog-command"
 import type { Session, Group, RemoteSession } from "@/core/types"
 import { isRemoteSession } from "@/core/types"
@@ -326,6 +326,11 @@ export function Home() {
         dialog.replace(() => <DialogSessions />)
       }
     } else {
+      // Check if user pressed Ctrl+D to delete current session (local only)
+      if (wasDeleteSessionRequested()) {
+        handleDelete(session)
+        return
+      }
       // Check if user pressed Ctrl+K to open command palette (local only)
       if (wasCommandPaletteRequested()) {
         command.open()


### PR DESCRIPTION
## Summary
- Adds **Ctrl+D** keybind inside attached tmux sessions to delete the current session
- Uses the existing signal file pattern (same as Ctrl+K for command palette and Ctrl+L for session list): creates `/tmp/agent-view-delete-session`, detaches, and the TUI picks up the signal to trigger the standard delete flow
- For worktree sessions, the confirmation dialog ("Delete session and worktree" / "Delete session only") is shown as usual
- Keybind hint added to the tmux status bar

## Changes
- `src/core/tmux.conf` — new `Ctrl+D` keybind + status bar hint
- `src/core/tmux.ts` — `DELETE_SESSION_SIGNAL` constant, `wasDeleteSessionRequested()` function, signal cleanup in `attachSessionSync`
- `src/tui/routes/home.tsx` — check for delete signal after detach, trigger `handleDelete()`

## Test plan
- [ ] Attach to a session, press Ctrl+D — should detach and show delete confirmation (or delete directly for non-worktree sessions)
- [ ] Attach to a worktree session, press Ctrl+D — should show "Delete session and worktree" / "Delete session only" dialog
- [ ] Press Ctrl+Q (regular detach) — should still work as before, no delete triggered
- [ ] Press Ctrl+K / Ctrl+L — should still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)