### PR TITLE
fix: clear terminal scrollback when switching between sessions

### DIFF
--- a/src/core/ssh.ts
+++ b/src/core/ssh.ts
@@ -139,7 +139,7 @@ export class SSHRunner {
 
     // Exit alternate screen buffer before attaching
     process.stdout.write("\x1b[?1049l")
-    process.stdout.write("\x1b[2J\x1b[H")
+    process.stdout.write("\x1b[2J\x1b[3J\x1b[H")
     process.stdout.write("\x1b[?25h")
 
     const sshArgs = [
@@ -159,7 +159,7 @@ export class SSHRunner {
 
     child.on("exit", () => {
       // Clear screen and re-enter alternate buffer for TUI
-      process.stdout.write("\x1b[2J\x1b[H")
+      process.stdout.write("\x1b[2J\x1b[3J\x1b[H")
       process.stdout.write("\x1b[?1049h")
       process.stdout.write("\x1b]0;Agent View\x07")
     })
@@ -175,7 +175,7 @@ export class SSHRunner {
 
     // Exit alternate screen buffer
     process.stdout.write("\x1b[?1049l")
-    process.stdout.write("\x1b[2J\x1b[H")
+    process.stdout.write("\x1b[2J\x1b[3J\x1b[H")
     process.stdout.write("\x1b[?25h")
 
     const sshArgs = [
@@ -207,7 +207,7 @@ export class SSHRunner {
     }
 
     // Clear screen and re-enter alternate buffer for TUI
-    process.stdout.write("\x1b[2J\x1b[H")
+    process.stdout.write("\x1b[2J\x1b[3J\x1b[H")
     process.stdout.write("\x1b[?1049h")
     process.stdout.write("\x1b]0;Agent View\x07")
 

--- a/src/core/tmux.conf
+++ b/src/core/tmux.conf
@@ -18,8 +18,10 @@ bind-key -n C-t if-shell "[ $(tmux display -p '#{window_panes}') -eq 1 ]" "split
 bind-key -n C-o select-pane -t :.+
 
 # Session switching (no prefix needed)
-bind-key -n C-] switch-client -n
-bind-key -n 'C-\' switch-client -p
+# refresh-client after switch forces a full terminal redraw to prevent
+# screen artifacts from the previous session.
+bind-key -n C-] switch-client -n \; refresh-client
+bind-key -n 'C-\' switch-client -p \; refresh-client
 bind-key -n C-l run-shell "touch /tmp/agent-view-session-list" \; detach-client
 
 # --- Status bar ---

--- a/src/core/tmux.ts
+++ b/src/core/tmux.ts
@@ -577,8 +577,8 @@ export async function attachWithPty(sessionName: string): Promise<void> {
         // PTY may already be closed
       }
 
-      // Clear screen before returning to TUI
-      process.stdout.write("\x1b[2J\x1b[H")
+      // Clear screen + scrollback before returning to TUI
+      process.stdout.write("\x1b[2J\x1b[3J\x1b[H")
     }
   })
 }
@@ -698,7 +698,7 @@ export function attachSessionSync(sessionName: string): void {
 
   // Exit alternate screen buffer (TUI uses this)
   process.stdout.write("\x1b[?1049l")
-  process.stdout.write("\x1b[2J\x1b[H")
+  process.stdout.write("\x1b[2J\x1b[3J\x1b[H") // Clear screen + scrollback
   process.stdout.write("\x1b[?25h")
 
   // Attach to tmux - this blocks until user detaches (Ctrl+Q or Ctrl+B d)
@@ -707,8 +707,8 @@ export function attachSessionSync(sessionName: string): void {
     env: process.env
   })
 
-  // Clear screen and re-enter alternate buffer for TUI
-  process.stdout.write("\x1b[2J\x1b[H")
+  // Clear screen + scrollback and re-enter alternate buffer for TUI
+  process.stdout.write("\x1b[2J\x1b[3J\x1b[H")
   process.stdout.write("\x1b[?1049h")
 
   // Restore terminal title to "Agent View"

--- a/src/core/updater.ts
+++ b/src/core/updater.ts
@@ -52,7 +52,7 @@ export function performUpdateSync(): void {
 
   // Exit alternate screen buffer
   process.stdout.write("\x1b[?1049l")
-  process.stdout.write("\x1b[2J\x1b[H")
+  process.stdout.write("\x1b[2J\x1b[3J\x1b[H")
   process.stdout.write("\x1b[?25h")
 
   spawnSync("bash", ["-c", "curl -fsSL https://raw.githubusercontent.com/frayo44/agent-view/main/install.sh | bash"], {
@@ -61,7 +61,7 @@ export function performUpdateSync(): void {
   })
 
   // Clear screen and re-enter alternate buffer for TUI
-  process.stdout.write("\x1b[2J\x1b[H")
+  process.stdout.write("\x1b[2J\x1b[3J\x1b[H")
   process.stdout.write("\x1b[?1049h")
 
   // Restore terminal title


### PR DESCRIPTION
## Summary
- Fixes previous session content appearing when scrolling up after switching sessions
- Adds `\x1b[3J` (clear scrollback buffer) alongside existing `\x1b[2J` (clear visible screen) in all screen transition points
- Adds `refresh-client` after `switch-client` for clean redraws on Ctrl+]/Ctrl+\

## Root cause
When attaching/detaching tmux sessions, the code only cleared the visible screen (`\x1b[2J`) but not the terminal's scrollback buffer. This meant the terminal emulator's scrollback retained output from the previous session since it was never cleared.

The fix adds `\x1b[3J` which is the standard ANSI escape sequence for clearing the terminal scrollback buffer. Supported by iTerm2, Terminal.app, and all modern terminal emulators.

For in-tmux session switching (Ctrl+]/Ctrl+\), `refresh-client` forces tmux to fully redraw after switching.

## Changes
- `src/core/tmux.ts` — `\x1b[3J` in `attachSessionSync()` and `attachWithPty()` cleanup
- `src/core/ssh.ts` — `\x1b[3J` in `attach()` and `attachSync()`
- `src/core/updater.ts` — `\x1b[3J` in `performUpdateSync()`
- `src/core/tmux.conf` — `refresh-client` after `switch-client`

## Test plan
- [ ] Attach to session A, do some work, press Ctrl+Q to detach
- [ ] Attach to session B, scroll up — should NOT see session A content
- [ ] While attached, press Ctrl+] to switch sessions — screen should render cleanly
- [ ] Scroll up after switching — should only see current session content